### PR TITLE
Make international_phone_input form friendly

### DIFF
--- a/lib/src/country.dart
+++ b/lib/src/country.dart
@@ -5,7 +5,9 @@ class Country {
 
   final String code;
 
+  final String code3;
+
   final String dialCode;
 
-  Country({this.name, this.code, this.flagUri, this.dialCode});
+  Country({this.name, this.code, this.code3, this.flagUri, this.dialCode});
 }

--- a/lib/src/international_phone_input.dart
+++ b/lib/src/international_phone_input.dart
@@ -10,14 +10,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class InternationalPhoneInput extends StatefulWidget {
-  final void Function(String phoneNumber, String internationalizedPhoneNumber,
-      String isoCode) onPhoneNumberChange;
+
+	static const String ERROR_TEXT = 'Please enter a valid phone number';
+	static const String HINT_TEXT = 'eg. 244056345';
+	static const String HELPER_TEXT = 'A valid phone number includes area/city code';
+	static const String LABEL_TEXT = 'Phone number';
+
+  final void Function(
+		String phoneNumber,
+	 	String internationalizedPhoneNumber,
+	 	String isoCode
+	) onPhoneNumberChange;
   final String initialPhoneNumber;
   final String initialSelection;
   final String errorText;
   final String hintText;
+	final String helperText;
+	final String labelText;
   final TextStyle errorStyle;
   final TextStyle hintStyle;
+  final TextStyle helperStyle;
+  final TextStyle labelStyle;
   final int errorMaxLines;
 	final bool showFlags;
 	final bool useTextFormField;
@@ -28,11 +41,15 @@ class InternationalPhoneInput extends StatefulWidget {
 		this.onPhoneNumberChange,
 		this.initialPhoneNumber,
 		this.initialSelection,
-		this.errorText,
-		this.hintText,
+		this.errorText = ERROR_TEXT,
+		this.hintText = HINT_TEXT,
+		this.helperText = HELPER_TEXT,
+		this.labelText = LABEL_TEXT,
 		this.errorStyle,
 		this.hintStyle,
-		this.errorMaxLines,
+		this.helperStyle,
+		this.labelStyle,
+		this.errorMaxLines = 3,
 		this.dialCodeFocusNode,
 		this.phoneTextFocusNode,
 		this.useTextFormField = false,
@@ -50,30 +67,17 @@ class InternationalPhoneInput extends StatefulWidget {
 
 class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
   Country selectedItem;
-  List<Country> itemList = [];
-
-  String errorText;
-  String hintText;
-
-  TextStyle errorStyle;
-  TextStyle hintStyle;
-
-  int errorMaxLines;
+  List<Country> itemList;
 
   bool hasError = false;
 
-  _InternationalPhoneInputState();
-
-  final phoneTextController = TextEditingController();
+  TextEditingController phoneTextController;
 
   @override
   void initState() {
-    errorText = widget.errorText ?? 'Please enter a valid phone number';
-    hintText = widget.hintText ?? 'eg. 244056345';
-    errorStyle = widget.errorStyle;
-    hintStyle = widget.hintStyle;
-    errorMaxLines = widget.errorMaxLines;
+		itemList = <Country>[];
 
+		phoneTextController = TextEditingController();
     phoneTextController.addListener(_validatePhoneNumber);
     phoneTextController.text = widget.initialPhoneNumber;
 
@@ -101,6 +105,12 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
 
     super.initState();
   }
+
+	@override
+	void dispose() {
+		phoneTextController.dispose();
+		super.dispose();
+	}
 
   _validatePhoneNumber() {
     String phoneText = phoneTextController.text;
@@ -193,11 +203,15 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
 							controller: phoneTextController,
 							focusNode: widget.phoneTextFocusNode,
 							decoration: InputDecoration(
-								hintText: hintText,
-								errorText: hasError ? errorText : null,
-								hintStyle: hintStyle ?? null,
-								errorStyle: errorStyle ?? null,
-								errorMaxLines: errorMaxLines ?? 3,
+								errorText: hasError ? widget.errorText : null,
+								hintText: widget.hintText,
+								helperText: widget.helperText,
+								labelText: widget.labelText,
+								errorStyle: widget.errorStyle,
+								hintStyle: widget.hintStyle,
+								helperStyle: widget.helperStyle,
+								labelStyle: widget.labelStyle,
+								errorMaxLines: widget.errorMaxLines,
 							),
 						),
 					),

--- a/lib/src/international_phone_input.dart
+++ b/lib/src/international_phone_input.dart
@@ -34,8 +34,10 @@ class InternationalPhoneInput extends StatefulWidget {
   final int errorMaxLines;
 	final bool showFlags;
 	final bool useTextFormField;
-	final dialCodeFocusNode;
-	final phoneTextFocusNode;
+	final FocusNode dialCodeFocusNode;
+	final FocusNode phoneTextFocusNode;
+	final TextInputAction phoneTextInputAction;
+	final void Function(String value) phoneTextOnFieldSubmitted;
 
   InternationalPhoneInput({
 		this.onPhoneNumberChange,
@@ -52,6 +54,8 @@ class InternationalPhoneInput extends StatefulWidget {
 		this.errorMaxLines = 3,
 		this.dialCodeFocusNode,
 		this.phoneTextFocusNode,
+		this.phoneTextInputAction,
+		this.phoneTextOnFieldSubmitted,
 		this.useTextFormField = false,
 		this.showFlags = true,
 	});
@@ -198,33 +202,53 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
             ),
           ),
           Flexible(
-            child: getTextField()(
-							keyboardType: TextInputType.phone,
-							controller: phoneTextController,
-							focusNode: widget.phoneTextFocusNode,
-							decoration: InputDecoration(
-								errorText: hasError ? widget.errorText : null,
-								hintText: widget.hintText,
-								helperText: widget.helperText,
-								labelText: widget.labelText,
-								errorStyle: widget.errorStyle,
-								hintStyle: widget.hintStyle,
-								helperStyle: widget.helperStyle,
-								labelStyle: widget.labelStyle,
-								errorMaxLines: widget.errorMaxLines,
-							),
-						),
+            child: _buildTextWidget(),
 					),
         ],
       ),
     );
   }
 
-	dynamic getTextField() {
-		if (widget.useTextFormField)
-			return TextFormField;
-		else
-			return TextField;
+	Widget _buildTextWidget() {
+		if (widget.useTextFormField) {
+			return TextFormField(
+				keyboardType: TextInputType.phone,
+				controller: phoneTextController,
+				focusNode: widget.phoneTextFocusNode,
+				textInputAction: widget.phoneTextInputAction,
+				onFieldSubmitted: widget.phoneTextOnFieldSubmitted,
+				decoration: InputDecoration(
+					errorText: hasError ? widget.errorText : null,
+					hintText: widget.hintText,
+					helperText: widget.helperText,
+					labelText: widget.labelText,
+					errorStyle: widget.errorStyle,
+					hintStyle: widget.hintStyle,
+					helperStyle: widget.helperStyle,
+					labelStyle: widget.labelStyle,
+					errorMaxLines: widget.errorMaxLines,
+				),
+			);
+		}
+		else {
+			return TextField(
+				keyboardType: TextInputType.phone,
+				controller: phoneTextController,
+				focusNode: widget.phoneTextFocusNode,
+				textInputAction: widget.phoneTextInputAction,
+				decoration: InputDecoration(
+					errorText: hasError ? widget.errorText : null,
+					hintText: widget.hintText,
+					helperText: widget.helperText,
+					labelText: widget.labelText,
+					errorStyle: widget.errorStyle,
+					hintStyle: widget.hintStyle,
+					helperStyle: widget.helperStyle,
+					labelStyle: widget.labelStyle,
+					errorMaxLines: widget.errorMaxLines,
+				),
+			);
+		}
 	}
 
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.36.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
@@ -21,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
@@ -50,13 +57,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.5"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -116,6 +130,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
   io:
     dependency: transitive
     description:
@@ -130,13 +151,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1+1"
-  json_rpc_2:
-    dependency: transitive
-    description:
-      name: json_rpc_2
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
   kernel:
     dependency: transitive
     description:
@@ -151,20 +165,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.11.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.8"
   mime:
     dependency: transitive
     description:
@@ -206,14 +227,21 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.4"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0+1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.0"
   pool:
     dependency: transitive
     description:
@@ -234,7 +262,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   shelf:
     dependency: transitive
     description:
@@ -309,7 +337,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   term_glyph:
     dependency: transitive
     description:
@@ -323,21 +351,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.3"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -352,13 +380,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
-  vm_service_client:
+  vm_service:
     dependency: transitive
     description:
-      name: vm_service_client
+      name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.6+3"
+    version: "2.3.1"
   watcher:
     dependency: transitive
     description:
@@ -373,6 +401,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.15"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.5.0"
   yaml:
     dependency: transitive
     description:
@@ -381,4 +416,4 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
Add the following:

- add `Country.code3` for filtering `initialSelection` and as substitute for `showFlags = false`
- `bool showFlags` to toggle showing flag assets
- `bool useTextFormField` to toggle `TextField` or `TextFormField`
- `FocusNode dialCodeFocusNode` and `FocusNode phoneTextFocusNode` to integrate focus navigation typically within a form
- `TextInputAction phoneTextInputAction` for specifying action button on keyboard
- `Function dialCodeOnChange` to hook into `DropdownButton.onChanged`